### PR TITLE
Fix ContextNotifier._work() running forever, ignore setuptools output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 *.pyc
 ausb.egg-info
+/build/
+/dist/

--- a/ausb/context.py
+++ b/ausb/context.py
@@ -33,6 +33,7 @@ class ContextNotifier:
         """
         self.context.setPollFDNotifiers()
         self.done.set()
+        self.fd_ready.set()
 
     @staticmethod
     def _fd_register(fd, events, self):


### PR DESCRIPTION
`ContextNotifier._work()` continues running even after `Context` is garbage collected. This PR fixes `ContextNotifier.close()` to actually cause `ContextNotifier._work()` to return. Please see the commit message for details.

In addition there's a small fix to `.gitignore` so that the output generated by `setup.py` gets ignored, reducing the risk of accidentally adding generated files to the repository. (I can open a separate PR for that if you prefer but it didn't seem worth the overhead).